### PR TITLE
Add dependency type to Dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,6 +2,7 @@ version: 2
 updates:
   - package-ecosystem: "npm"
     directory: "/"
+    dependency-type: "production"
     schedule:
       interval: "weekly"
       day: "monday"


### PR DESCRIPTION
This pull request makes a small configuration update to the Dependabot settings. The change specifies that only production dependencies should be updated for the npm ecosystem.