### PR TITLE
Revise resume summary and experience details

### DIFF
--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -62,14 +62,14 @@ export const siteMetadata: Metadata = {
 
 export const socialLinks: SocialLink[] = [
   {
-    name: "GitHub",
-    href: "https://www.github.com/brignano",
-    icon: GitHubIcon,
-  },
-  {
     name: "LinkedIn",
     href: "https://www.linkedin.com/in/brignano",
     icon: LinkedinIcon,
+  },
+  {
+    name: "GitHub",
+    href: "https://www.github.com/brignano",
+    icon: GitHubIcon,
   },
   {
     name: "WakaTime",

--- a/public/resume.yml
+++ b/public/resume.yml
@@ -94,7 +94,7 @@ experience:
       - Served as the primary point of owner for full-stack applications across software, data, and infrastructure
       - Led triage and restoration of high-impact production incidents
       - Championed migration to open-source platforms, containerization, and public cloud
-      - Led adoption of DevOps tools and practices across the organizations portfolio
+      - Led adoption of DevOps tools and practices across the organization's portfolio
     technologies:
       - .NET
       - Oracle

--- a/public/resume.yml
+++ b/public/resume.yml
@@ -7,7 +7,7 @@ personalInfo:
   linkedin: https://www.linkedin.com/in/brignano
   github: https://github.com/brignano
 summary: |
-  Senior Staff Platform Engineer and architect focused on enterprise developer experience, internal developer platforms, and AI-native software delivery. I design and scale the systems that thousands of engineers rely on-spanning CI/CD, DevOps intelligence, cloud platforms, and AI/ML enablement. My work emphasizes paved roads, self-service platforms, and treating developer experience as a first-class product.
+  Senior Staff Platform Engineer and architect focused on enterprise developer experience, internal developer platforms, and AI-native software delivery. I design and scale the systems that thousands of engineers rely on, spanning CI/CD, DevOps intelligence, cloud platforms, and AI/ML enablement. My work emphasizes paved roads, self-service platforms, and treating developer experience as a first-class product.
 experience:
   - company: The Hartford
     position: Senior Staff Software Engineer — Enterprise Platform Engineering
@@ -15,14 +15,14 @@ experience:
     startDate: 2023
     endDate: Present
     summary: |
-      Technical Lead for The Hartford's enterprise developer platform and developer experience strategy. Owns the architecture and evolution of internal platforms spanning CI/CD, DevOps intelligence, internal developer protals, AI/ML enablement, and cloud delivery accross thousands of repositories.
+      Technical Lead for The Hartford's enterprise developer platform and developer experience strategy. Owns the architecture and evolution of internal platforms spanning CI/CD, DevOps intelligence, internal developer portals, AI/ML enablement, and cloud delivery accross thousands of repositories.
     highlights:
       - Serve as a principal architect for the enterprise developer platform, defining long-term strategy for developer experience, delivery automation, and AI-native software delivery
-      - Lead the design and rollout of internal developer platform capabiltiies, including standardizwed pipelines, self-service workflows, and opinionated paved roads
-      - Architect and deliver a unified DevOps intelligence layer aggregating SDLC signals into actionable context for developers, playforms, and AI agents
+      - Lead the design and rollout of internal developer platform capabiltiies, including standardized pipelines, self-service workflows, and opinionated paved roads
+      - Architect and deliver a unified DevOps intelligence layer aggregating SDLC signals into actionable context for developers, platforms, and AI agents
       - Lead development of an enterprise CLI providing a single command surface for build execution, pipeline interaction, and developer workflows
       - Drive platform-wide developer telemtry and workflow instrumentation to improve reliability, productivity, and time-to-resolution
-      - Provide architectural leadership across a heterogeneous CI/CD ecosystemm (GitHub Actions, Harness, Jenkins, AWS CodePipeline, UrbanCode Deploy, etc.)
+      - Provide architectural leadership across a heterogeneous CI/CD ecosystem (GitHub Actions, Harness, Jenkins, AWS CodePipeline, UrbanCode Deploy, etc.)
       - Led enterprise migration from GitHub Enterprise Server to GitHub Enterprise Cloud, modernizing over 11,000 repositories in under 12 months
       - Enable AI/ML delivery at scale through standardized platform patterns and pipelines for Google Cloud and Vertex AI workloads
       - Treat developer experience as a product, balancing platform abstraction, governance, and developer autonomy
@@ -33,7 +33,7 @@ experience:
       - Cloud Platforms (AWS, Google Cloud Platform)
       - AI/ML Platforms (Vertex AI)
       - Infrastructure as Code (Terraform)
-      - Observability & Telemtry (Dynatrace)
+      - Observability & Telemetry (Dynatrace)
   - company: The Hartford
     position: Staff Software Engineer — Enterprise Quality Engineering
     location: Hartford, CT
@@ -93,8 +93,8 @@ experience:
     highlights:
       - Served as the primary point of owner for full-stack applications across software, data, and infrastructure
       - Led triage and restoration of high-impact production incidents
-      - Championed migration to open-source platofrms, containerization, and public cloud
-      - Led adoption of DevOps tools and practices across the organizations portolfio
+      - Championed migration to open-source platforms, containerization, and public cloud
+      - Led adoption of DevOps tools and practices across the organizations portfolio
     technologies:
       - .NET
       - Oracle
@@ -108,7 +108,7 @@ experience:
     endDate: 2017
     summary: Drove delivery and production stability for an internal policy quoting and issuance application, supporting Personal Insurance agents.
     highlights:
-      - Led Agile scrum team design a new internal quoting and issuance application
+      - Led an Agile scrum team to design a new internal quoting and issuance application
       - Integrated multiple internal and external services to streamline agent workflows
       - Resolved 1,500+ production defects and incidents
     technologies:

--- a/public/resume.yml
+++ b/public/resume.yml
@@ -91,7 +91,7 @@ experience:
     endDate: 2018
     summary: Owned application platforms and production operations, focusing on reliability, modernization, and DevOps enablement across the application portfolio.
     highlights:
-      - Served as the primary point of owner for full-stack applications across software, data, and infrastructure
+      - Served as the primary point of ownership for full-stack applications across software, data, and infrastructure
       - Led triage and restoration of high-impact production incidents
       - Championed migration to open-source platforms, containerization, and public cloud
       - Led adoption of DevOps tools and practices across the organization's portfolio

--- a/public/resume.yml
+++ b/public/resume.yml
@@ -7,35 +7,33 @@ personalInfo:
   linkedin: https://www.linkedin.com/in/brignano
   github: https://github.com/brignano
 summary: |
-  Full-stack engineer working at the intersection of DevSecOps, automation, and cloud-native systems. I build secure, reliable cloud-native systems and the platforms teams depend on. My approach emphasizes automation, strong testing practices, and security as a first-class concern.
+  Senior Staff Platform Engineer and architect focused on enterprise developer experience, internal developer platforms, and AI-native software delivery. I design and scale the systems that thousands of engineers rely on-spanning CI/CD, DevOps intelligence, cloud platforms, and AI/ML enablement. My work emphasizes paved roads, self-service platforms, and treating developer experience as a first-class product.
 experience:
   - company: The Hartford
     position: Senior Staff Software Engineer — Enterprise Platform Engineering
     location: Hartford, CT
     startDate: 2023
     endDate: Present
-    summary: Leading architecture and strategy for the enterprise developer platform ecosystem, spanning CI/CD, AI/ML enablement, security, artifact management, observability, and developer experience across thousands of repositories.
+    summary: |
+      Technical Lead for The Hartford's enterprise developer platform and developer experience strategy. Owns the architecture and evolution of internal platforms spanning CI/CD, DevOps intelligence, internal developer protals, AI/ML enablement, and cloud delivery accross thousands of repositories.
     highlights:
-      - Serve as solution architect for the Platform Engineering organization, defining standards and long-term strategy across enterprise software delivery platforms
-      - Provide architectural oversight across a multi-platform CI/CD ecosystem (GitHub Actions, Harness, Jenkins, AWS CodePipeline, UrbanCode Deploy)
-      - Drove enterprise migration from GitHub Enterprise Server to GitHub Enterprise Cloud (11,000+ repositories in under 12 months)
-      - Architecting an internal developer platform layer to unify build execution, pipeline interaction, and developer workflows across heterogeneous tech stacks
-      - Leading development of enterprise-standardized build tooling enabling consistent single-command builds across the organization
-      - Driving platform-wide developer telemetry and workflow instrumentation to improve reliability, productivity, and incident reduction
-      - Supporting onboarding of Google Cloud projects and modern delivery patterns for Vertex AI and AI/ML workloads
-      - Built and operated scalable CI/CD execution, governance, and observability platforms using infrastructure as code
-      - Recognized with the 2023 Enterprise Tech Data & Cyber Award for platform adoption and productivity
+      - Serve as a principal architect for the enterprise developer platform, defining long-term strategy for developer experience, delivery automation, and AI-native software delivery
+      - Lead the design and rollout of internal developer platform capabiltiies, including standardizwed pipelines, self-service workflows, and opinionated paved roads
+      - Architect and deliver a unified DevOps intelligence layer aggregating SDLC signals into actionable context for developers, playforms, and AI agents
+      - Lead development of an enterprise CLI providing a single command surface for build execution, pipeline interaction, and developer workflows
+      - Drive platform-wide developer telemtry and workflow instrumentation to improve reliability, productivity, and time-to-resolution
+      - Provide architectural leadership across a heterogeneous CI/CD ecosystemm (GitHub Actions, Harness, Jenkins, AWS CodePipeline, UrbanCode Deploy, etc.)
+      - Led enterprise migration from GitHub Enterprise Server to GitHub Enterprise Cloud, modernizing over 11,000 repositories in under 12 months
+      - Enable AI/ML delivery at scale through standardized platform patterns and pipelines for Google Cloud and Vertex AI workloads
+      - Treat developer experience as a product, balancing platform abstraction, governance, and developer autonomy
+      - Recognized with the 2023 Enterprise Tech Data & Cyber Award for platform adoption and productivity impact
     technologies:
-      - GitHub Actions
-      - GitHub Enterprise Cloud
-      - Terraform
-      - AWS
-      - GCP
-      - Harness
-      - Jenkins
-      - AWS CodePipeline
-      - UrbanCode Deploy
-      - Dynatrace
+      - Internal Developer Platforms (IDP)
+      - CI/CD Platforms (GitHub Actions, Harness, Jenkins, AWS CodePipeline, UrbanCode Deploy)
+      - Cloud Platforms (AWS, Google Cloud Platform)
+      - AI/ML Platforms (Vertex AI)
+      - Infrastructure as Code (Terraform)
+      - Observability & Telemtry (Dynatrace)
   - company: The Hartford
     position: Staff Software Engineer — Enterprise Quality Engineering
     location: Hartford, CT
@@ -48,10 +46,10 @@ experience:
       - Established SDLC and automation standards across the organization
       - Reduced end-to-end test execution time by 30%+
     technologies:
+      - Playwright
       - Selenium
       - Cypress
       - Jenkins
-      - TestNG
       - Maven
   - company: The Hartford
     position: Senior Software Engineer — Batch Processing Modernization
@@ -75,7 +73,7 @@ experience:
     location: Hartford, CT
     startDate: 2018
     endDate: 2020
-    summary: Built and supported customer-facing policy quoting and issuance platforms for Personal Lines insurance, enabling real-time pricing and issuance workflows.
+    summary: Built and supported customer-facing policy quoting and issuance platforms for Personal Lines insurance.
     highlights:
       - Developed Java microservices and Angular-based frontend features supporting quoting and issuance
       - Integrated Oracle databases and third-party services for pricing and issuance
@@ -93,12 +91,10 @@ experience:
     endDate: 2018
     summary: Owned application platforms and production operations, focusing on reliability, modernization, and DevOps enablement across the application portfolio.
     highlights:
-      - Served as the primary point of ownership for full-stack applications spanning software, databases, platforms, and infrastructure
-      - Led triage and restoration of high-impact production incidents, minimizing service disruption
-      - Drove root cause analysis and problem management practices to prevent recurring issues
-      - Championed migration to open-source platforms, containerization, and public cloud deployment
-      - Led adoption of DevOps tools and best practices across the application portfolio
-      - Influenced major technical design decisions in partnership with architecture and delivery teams
+      - Served as the primary point of owner for full-stack applications across software, data, and infrastructure
+      - Led triage and restoration of high-impact production incidents
+      - Championed migration to open-source platofrms, containerization, and public cloud
+      - Led adoption of DevOps tools and practices across the organizations portolfio
     technologies:
       - .NET
       - Oracle
@@ -112,10 +108,9 @@ experience:
     endDate: 2017
     summary: Drove delivery and production stability for an internal policy quoting and issuance application, supporting Personal Insurance agents.
     highlights:
-      - Led an Agile scrum team in the design and architecture of a new internal application for quoting and issuing Personal Insurance policies
-      - Integrated multiple internal and external web services to streamline workflows and reduce agent handling time
-      - Resolved 1,500+ production defects and incidents, ensuring reliable application performance
-      - Supported ongoing enhancements and operational stability for a mission-critical internal system
+      - Led Agile scrum team design a new internal quoting and issuance application
+      - Integrated multiple internal and external services to streamline agent workflows
+      - Resolved 1,500+ production defects and incidents
     technologies:
       - .NET
       - Oracle


### PR DESCRIPTION
This pull request updates the `public/resume.yml` file to better reflect the scope and impact of recent roles, with improved descriptions of responsibilities, achievements, and technologies. The changes emphasize platform engineering, developer experience, and AI/ML enablement, and clarify highlights and summaries across multiple positions.

**Role and responsibility updates:**

* Updated the summary and highlights for the Senior Staff Software Engineer role at The Hartford to emphasize platform engineering, developer experience, and AI-native software delivery, including leadership in CI/CD, DevOps intelligence, internal developer platforms, and migration initiatives.
* Clarified and condensed highlights for previous roles, focusing on ownership, migration to modern platforms, incident response, and DevOps enablement. [[1]](diffhunk://#diff-938db2efe88bcbba1e4eaa0fff6d341a45ddae9a13e8fc22b36b8a4b5eefab18L96-R97) [[2]](diffhunk://#diff-938db2efe88bcbba1e4eaa0fff6d341a45ddae9a13e8fc22b36b8a4b5eefab18L115-R113)
* Refined summary for customer-facing policy quoting and issuance platform work to remove redundancy.

**Technology stack updates:**

* Updated technology lists to include Internal Developer Platforms, AI/ML platforms, and observability/telemetry tools, and added `Playwright` for quality engineering. [[1]](diffhunk://#diff-938db2efe88bcbba1e4eaa0fff6d341a45ddae9a13e8fc22b36b8a4b5eefab18L10-R36) [[2]](diffhunk://#diff-938db2efe88bcbba1e4eaa0fff6d341a45ddae9a13e8fc22b36b8a4b5eefab18R49-L54)