### PR TITLE
Enhance experience toggle functionality with scroll locking on mobile devices

### DIFF
--- a/app/resume/page.tsx
+++ b/app/resume/page.tsx
@@ -82,19 +82,29 @@ export default function Home() {
       const opened = window.open(pdfBlobUrl, "_blank");
 
       if (opened) {
-        // After a short delay, ensure the window scrolls to the very top
-        // This prevents grey space on mobile
+        // After the PDF loads, ensure the window scrolls to the very top
+        // and remove all default margins/padding that cause grey space on mobile
         setTimeout(() => {
           try {
             opened.scrollTo(0, 0);
-            if (opened.document && opened.document.body) {
-              opened.document.body.style.margin = "0";
-              opened.document.body.style.padding = "0";
+            if (opened.document) {
+              const html = opened.document.documentElement;
+              const body = opened.document.body;
+              
+              // Reset html element
+              html.style.margin = "0";
+              html.style.padding = "0";
+              html.style.border = "none";
+              
+              // Reset body element
+              body.style.margin = "0";
+              body.style.padding = "0";
+              body.style.border = "none";
             }
           } catch (e) {
-            // Ignore cross-origin errors
+            // Ignore cross-origin errors (expected on some mobile browsers)
           }
-        }, 100);
+        }, 200);
       } else {
         // Fallback to download if popup was blocked
         const link = document.createElement("a");

--- a/app/resume/page.tsx
+++ b/app/resume/page.tsx
@@ -90,12 +90,12 @@ export default function Home() {
             if (opened.document) {
               const html = opened.document.documentElement;
               const body = opened.document.body;
-              
+
               // Reset html element
               html.style.margin = "0";
               html.style.padding = "0";
               html.style.border = "none";
-              
+
               // Reset body element
               body.style.margin = "0";
               body.style.padding = "0";

--- a/app/resume/page.tsx
+++ b/app/resume/page.tsx
@@ -49,6 +49,7 @@ export default function Home() {
 
     const initialScrollY = window.scrollY;
     const cardTop = cardElement.getBoundingClientRect().top;
+    const isExpanding = expandedIndex !== index;
 
     scrollAnchorRef.current = {
       index,
@@ -58,8 +59,8 @@ export default function Home() {
 
     setExpandedIndex((prev) => (prev === index ? null : index));
 
-    // On mobile, immediately lock the scroll position
-    if (window.innerWidth < 768) {
+    // On mobile, lock the scroll position only when expanding
+    if (window.innerWidth < 768 && isExpanding) {
       const preventScroll = () => {
         if (window.scrollY !== initialScrollY) {
           window.scrollTo(0, initialScrollY);
@@ -211,7 +212,13 @@ export default function Home() {
       return;
     }
 
-    const anchorYStart = anchor.top;
+    // Only apply scroll lock during expand, not collapse
+    const isExpanding = expandedIndex === anchor.index;
+    if (!isExpanding) {
+      scrollAnchorRef.current = null;
+      return;
+    }
+
     let lastLayoutTop = cardElement.getBoundingClientRect().top;
 
     const adjustScroll = () => {

--- a/app/resume/page.tsx
+++ b/app/resume/page.tsx
@@ -92,7 +92,21 @@ export default function Home() {
       const pdfBlobUrl = URL.createObjectURL(blob);
       const opened = window.open(pdfBlobUrl, "_blank");
 
-      if (!opened) {
+      if (opened) {
+        // After a short delay, ensure the window scrolls to the very top
+        // This prevents grey space on mobile
+        setTimeout(() => {
+          try {
+            opened.scrollTo(0, 0);
+            if (opened.document && opened.document.body) {
+              opened.document.body.style.margin = "0";
+              opened.document.body.style.padding = "0";
+            }
+          } catch (e) {
+            // Ignore cross-origin errors
+          }
+        }, 100);
+      } else {
         // Fallback to download if popup was blocked
         const link = document.createElement("a");
         link.href = pdfBlobUrl;

--- a/app/resume/page.tsx
+++ b/app/resume/page.tsx
@@ -41,13 +41,15 @@ export default function Home() {
       event.preventDefault();
     }
 
-    // Scroll the card to the top of the viewport only if it's not currently visible
+    // Scroll the card into view only if it's not currently visible
     const rect = cardElement.getBoundingClientRect();
 
     // Only scroll if the card is out of view (above or below the viewport)
     if (rect.top < 0 || rect.top > window.innerHeight) {
-      const scrollTop = window.scrollY + rect.top;
-      window.scrollTo(0, scrollTop);
+      // Scroll with padding from the top so the header stays visible after expansion
+      const paddingFromTop = 80;
+      const scrollTop = window.scrollY + rect.top - paddingFromTop;
+      window.scrollTo(0, Math.max(0, scrollTop));
     }
 
     // Disable scrolling during animation

--- a/app/resume/page.tsx
+++ b/app/resume/page.tsx
@@ -41,10 +41,14 @@ export default function Home() {
       event.preventDefault();
     }
 
-    // Scroll the card to the top of the viewport
+    // Scroll the card to the top of the viewport only if it's not currently visible
     const rect = cardElement.getBoundingClientRect();
-    const scrollTop = window.scrollY + rect.top;
-    window.scrollTo(0, scrollTop);
+
+    // Only scroll if the card is out of view (above or below the viewport)
+    if (rect.top < 0 || rect.top > window.innerHeight) {
+      const scrollTop = window.scrollY + rect.top;
+      window.scrollTo(0, scrollTop);
+    }
 
     // Disable scrolling during animation
     const originalOverflow = document.body.style.overflow;


### PR DESCRIPTION
This pull request updates the experience card expansion logic on the resume page to improve scroll behavior, particularly on mobile devices and for keyboard accessibility. The main changes ensure the scroll position is locked during animation on mobile, prevent default scrolling on keyboard interaction, and make the scroll adjustment smoother and more robust.

**Accessibility and scroll behavior improvements:**

* Updated `toggleExperience` to accept the triggering event and prevent default scrolling for keyboard events, improving accessibility and preventing unexpected jumps when using the keyboard. [[1]](diffhunk://#diff-a5b785c3ffb49da984a7500ded3bac0c137dd04408950109151ba71e63aeea8aR38-R72) [[2]](diffhunk://#diff-a5b785c3ffb49da984a7500ded3bac0c137dd04408950109151ba71e63aeea8aL372-R406)
* Added logic to lock the scroll position on mobile devices during the experience card expand/collapse animation, preventing scroll drift.

**Scroll adjustment robustness:**

* Refined the scroll adjustment logic to use incremental shifts based on layout changes, resulting in smoother and more accurate scroll corrections during card expansion/collapse. [[1]](diffhunk://#diff-a5b785c3ffb49da984a7500ded3bac0c137dd04408950109151ba71e63aeea8aR214-R216) [[2]](diffhunk://#diff-a5b785c3ffb49da984a7500ded3bac0c137dd04408950109151ba71e63aeea8aL202-R236)